### PR TITLE
fix: replace botan with openssl 3.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,15 +58,14 @@ quic/quic/stream_manager.cpp
 quic/quic/util.cpp
 quic/quic/variable_length_integer.cpp
 )
+
 add_executable(quic_client ${SOURCE_FILES})
 target_compile_definitions(quic_client PUBLIC -DOPEN_MODE2=\"rb\")
-target_include_directories(quic_client PUBLIC /usr/include/botan-2)
-target_link_libraries(quic_client crypto ssl botan-2 pthread)
+target_link_libraries(quic_client crypto ssl pthread)
 install(TARGETS quic_client DESTINATION ${DIVISIBLE_INSTALL_BIN_DIR})
 
 # client_initial test
 add_executable(client_initial_test ${SOURCE_FILES})
 target_compile_definitions(client_initial_test PUBLIC -DOPEN_MODE2=\"rb\")
-target_include_directories(client_initial_test PUBLIC /usr/include/botan-2)
-target_link_libraries(client_initial_test crypto ssl botan-2 pthread)
+target_link_libraries(client_initial_test crypto ssl pthread)
 install(TARGETS client_initial_test DESTINATION ${DIVISIBLE_INSTALL_BIN_DIR})

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Ubuntu 20.04
 # requirement
 
 - CMake >= v3.2
-- OpenSSL v1.1.1f
-- libbotan-2-dev/focal,now 2.12.1-2build1 amd64
-
+- OpenSSL v3.1.0
 
 # How to use
 ## How to build

--- a/quic/tls/hkdf.hpp
+++ b/quic/tls/hkdf.hpp
@@ -5,8 +5,6 @@
 #include <string>
 #include <vector>
 
-#include <botan-2/botan/hkdf.h>
-#include <botan-2/botan/hmac.h>
 #include <openssl/evp.h>
 
 #include "../tls/hash.hpp"

--- a/quic/tls/key_schedule.hpp
+++ b/quic/tls/key_schedule.hpp
@@ -3,9 +3,6 @@
 #include <iostream>
 #include <vector>
 
-#include <botan-2/botan/hkdf.h>
-#include <botan-2/botan/hmac.h>
-
 #include <openssl/ssl.h>
 
 #include "hash.hpp"


### PR DESCRIPTION
Some API is not inplemented in OpenSSL 1.1.1. So, botan was used. 

Those APIs are implemented in OpenSSL 3.0. By using OpenSSL 3.0, Botan is no longer needed. 