### PR TITLE
Replace deprecated api of openssl

### DIFF
--- a/quic/quic/unprotect_packet.cpp
+++ b/quic/quic/unprotect_packet.cpp
@@ -187,7 +187,7 @@ void UnprotectPacket::UnprotectPayload(std::vector<uint8_t> &header,
       evp, original_payload + original_payload_sz, &original_payload_sz);
   if (test <= 0 && ERR_get_error() != 0) {
     fprintf(stderr,
-            "ERROR: EVP_CipherFinal_ex failed. OpenSSL error: %s\n",
+            "ERROR: EVP_CipherFinal_ex failed. test: %d, OpenSSL error: %s\n",test,
             ERR_error_string(ERR_get_error(), NULL));
     return;
   }

--- a/quic/tls/ecdh.cpp
+++ b/quic/tls/ecdh.cpp
@@ -1,8 +1,12 @@
 #include "ecdh.hpp"
 
+#include <openssl/core_names.h>
+
 namespace tls {
 
 bool ECDH::CreateKey(void) {
+  EVP_PKEY_CTX *pctx;
+
   if (NULL == (key_ = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1))) {
     printf("Failed to create key curve\n");
     return false;
@@ -13,18 +17,66 @@ bool ECDH::CreateKey(void) {
     return false;
   }
 
-  // EC_KEY_print_fp(stdout, key_, 0);
+  EC_KEY_print_fp(stdout, key_, 0);
+
+  // new implementation
+  // https://www.openssl.org/docs/man3.1/man7/EVP_PKEY-EC.html
+  pkey_ = EVP_EC_gen("prime256v1");
+  printf("result of EVP_EC_GEN %x\n", pkey_);
+  OSSL_PARAM params[2];
+  pctx_ = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+
+  EVP_PKEY_keygen_init(pctx_);
+
+  params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, "P-256", 0);
+
+  params[1] = OSSL_PARAM_construct_end();
+  EVP_PKEY_CTX_set_params(pctx_, params);
+
+  EVP_PKEY_generate(pctx_, &pkey_);
+
+ // https://www.openssl.org/docs/man3.0/man3/BIO_s_fd.html
+  BIO *out;
+  out = BIO_new_fd(fileno(stdout), BIO_NOCLOSE);
+  BIO_printf(out, "------------------------ Hello World ------------------\n");
+  BIO_printf(out, "PublicKey\n");
+  EVP_PKEY_print_public(out, pkey_, 0, NULL);
+  BIO_printf(out, "PrivateKey\n");
+  EVP_PKEY_print_private(out, pkey_, 0, NULL);
+  BIO_free(out);
 
   return true;
 }
 
 std::vector<uint8_t> ECDH::GetPublicKey() {
-  int size = i2o_ECPublicKey(key_, nullptr);
+  // internal to octet
+  int size = i2o_ECPublicKey(key_, nullptr); // deprecated
   unsigned char *buf = new unsigned char[size];
   std::vector<uint8_t> ret(size);
   i2o_ECPublicKey(key_, &buf);
   buf -= size;
   std::copy(buf, buf + size, ret.begin());
+
+  // new implementation
+  size_t out_pubkey_len = 0;
+  // get length
+  if (!EVP_PKEY_get_octet_string_param(pkey_, OSSL_PKEY_PARAM_PUB_KEY, NULL, 0, &out_pubkey_len)) {
+    fprintf(stderr, "Failed to get public key\n");
+    std::exit(1);
+  }
+
+  std::vector<uint8_t> ret2(out_pubkey_len);
+  if (!EVP_PKEY_get_octet_string_param(pkey_, OSSL_PKEY_PARAM_PUB_KEY, ret2.data(), out_pubkey_len, &out_pubkey_len)) {
+    fprintf(stderr, "Failed to get public key\n");
+    std::exit(1);
+  }
+
+  BIO_dump_indent_fp(stdout, ret2.data(), out_pubkey_len, 2);
+  for(int i = 0;i < out_pubkey_len;i++){
+    printf("%02x", ret2[i]);
+  }
+  printf("\n");
+
   return ret;
 }
 
@@ -44,7 +96,7 @@ void ECDH::SetPeerPublicKey(std::vector<uint8_t> &public_key_vec) {
 
 std::vector<uint8_t> ECDH::GetSecret() {
   int field_size;
-  field_size = EC_GROUP_get_degree(EC_KEY_get0_group(key_));
+  field_size = EC_GROUP_get_degree(EC_KEY_get0_group(key_)); // deprecated
   if (field_size <= 0) {
     fprintf(stdout, "EC_GROUP_get_degree\n");
     std::exit(1);
@@ -55,7 +107,7 @@ std::vector<uint8_t> ECDH::GetSecret() {
   std::vector<uint8_t> secret(secret_len);
 
   secret_len =
-      ECDH_compute_key(secret.data(), secret_len, peer_, key_, NULL);
+      ECDH_compute_key(secret.data(), secret_len, peer_, key_, NULL); // deprecated
   if (secret_len <= 0) {
     std::exit(1);
   }

--- a/quic/tls/ecdh.cpp
+++ b/quic/tls/ecdh.cpp
@@ -8,6 +8,7 @@
 namespace tls {
 
 bool ECDH::CreateKey(void) {
+  /*
   if (NULL == (key_ = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1))) {
     printf("Failed to create key curve\n");
     return false;
@@ -19,16 +20,17 @@ bool ECDH::CreateKey(void) {
   }
 
   EC_KEY_print_fp(stdout, key_, 0);
+  */
 
   // new implementation
   // https://www.openssl.org/docs/man3.1/man7/EVP_PKEY-EC.html
   pkey_ = EVP_EC_gen("prime256v1");
-  printf("result of EVP_EC_GEN %x\n", pkey_);
   OSSL_PARAM params[2];
   //pctx_ = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
   pctx_ = EVP_PKEY_CTX_new_from_name(NULL, "X25519", NULL);
 
-  params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, "P-256", 0);
+  char param[32] = "P-256";
+  params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, param, 0);
 
   params[1] = OSSL_PARAM_construct_end();
   EVP_PKEY_CTX_set_params(pctx_, params);
@@ -49,6 +51,7 @@ bool ECDH::CreateKey(void) {
 }
 
 std::vector<uint8_t> ECDH::GetPublicKey() {
+/*
   // internal to octet
   int size = i2o_ECPublicKey(key_, nullptr); // deprecated
   unsigned char *buf = new unsigned char[size];
@@ -57,6 +60,7 @@ std::vector<uint8_t> ECDH::GetPublicKey() {
   buf -= size;
   std::copy(buf, buf + size, ret.begin());
   return ret;
+*/
 
   // new implementation
   size_t out_pubkey_len = 0;
@@ -82,6 +86,7 @@ std::vector<uint8_t> ECDH::GetPublicKey() {
 }
 
 void ECDH::SetPeerPublicKey(std::vector<uint8_t> &public_key_vec) {
+/*
   int error;
   BN_CTX *bn_ctx = BN_CTX_new();
   EC_GROUP *ec_group = EC_GROUP_new_by_curve_name(
@@ -94,91 +99,13 @@ void ECDH::SetPeerPublicKey(std::vector<uint8_t> &public_key_vec) {
     fprintf(stdout, "EC_POINT_oct2point failed\n");
     std::exit(1);
   }
-
+*/
 
   // new implementation
-  //EVP_PKEY_set_octet_string_param
-  
-  //https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_set_octet_string_param.html
-  //EVP_PKEY_derive_set_peer(pctx_, ?);
-
-/*
   peer_pkey_ = EVP_PKEY_new();
-  peer_pkey_ = EVP_EC_gen("prime256v1");
-  int nid = EVP_PKEY_get_id(pkey_);
-  int type = EVP_PKEY_type(nid); 
+  int error;
 
-  if (EVP_PKEY_set_type(peer_pkey_, type) == 0) {
-    fprintf(stderr, "EVP_PKEY_set_type failed\n");
-    std::exit(1);
-  }
-
-  BIO *out;
-  out = BIO_new_fd(fileno(stdout), BIO_NOCLOSE);
-  BIO_printf(out, "------------------------ Hello World2 ------------------\n");
-  BIO_printf(out, "PrivateKey\n");
-  EVP_PKEY_print_private(out, peer_pkey_, 0, NULL);
-*/
-
-  //peer_pkey_ = EVP_EC_gen("prime256v1");
-  /*
-  if (EVP_PKEY_set_octet_string_param(peer_pkey_, OSSL_PKEY_PARAM_PUB_KEY, public_key_vec.data(), public_key_vec.size()) == 0) {
-    fprintf(stderr, "Failed to set public key\n");
-    std::exit(1);
-  }
-  */
-
-/*
-  const unsigned char *p2;
-  p2 = public_key_vec.data();
-  peer_pkey_ = EVP_PKEY_new();
-  printf("test: %x\n", peer_pkey_);
-  d2i_PUBKEY(&peer_pkey_, &p2, public_key_vec.size());
-  printf("test: %x\n", peer_pkey_);
-*/
-
-/*
-  char error_string[256];
-  ERR_error_string(error, error_string);
-  printf("Error during deserialization: %s\n", error_string);
-*/
-
-
-/*
-  EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(pkey_, NULL);
-  EVP_PKEY_derive_init(ctx);
-  EVP_PKEY_derive_set_peer(ctx, peer_pkey_);
-
-  size_t shared_secret_len;
-  EVP_PKEY_derive(ctx, NULL, &shared_secret_len);
-  std::vector<uint8_t> shared_secret(shared_secret_len);
-  EVP_PKEY_derive(ctx, shared_secret.data(), &shared_secret_len);
-*/
-
-/*
-  peer_pkey_ = EVP_PKEY_new();
-  FILE *stream = fmemopen(public_key_vec.data(), public_key_vec.size(), "r");
-
-	BIO *bioPubKey = BIO_new_fp(stream, BIO_NOCLOSE);
-	PEM_read_bio_PUBKEY(bioPubKey, &peer_pkey_, NULL, NULL);
-	BIO_free(bioPubKey);
-*/
-
-  /*
-  printf("test\n");
-  unsigned char *p = public_key_vec.data();
-  //peer_pkey_ = EVP_PKEY_new_raw_public_key(EVP_PKEY_EC, NULL, public_key_vec.data(), public_key_vec.size());
-  peer_pkey_ = EVP_PKEY_new_raw_public_key(EVP_PKEY_X25519, NULL,  (unsigned char*)key_, sizeof(key_));
-  printf("peer_pkey: %x\n", peer_pkey_);
-  char error_string[256];
-  ERR_error_string(error, error_string);
-  printf("Error during deserialization: %s\n", error_string);
-  */
-
-
-  peer_pkey_ = EVP_PKEY_new();
-
-  if (EVP_PKEY_copy_parameters(peer_pkey_, pkey_) < 0) {
+  if ((error = EVP_PKEY_copy_parameters(peer_pkey_, pkey_)) < 0) {
     fprintf(stderr, "EVP_PKEY_copy_parameters failed: error %d\n", error);
     std::exit(1);
   }
@@ -209,6 +136,7 @@ void ECDH::SetPeerPublicKey(std::vector<uint8_t> &public_key_vec) {
 }
 
 std::vector<uint8_t> ECDH::GetSecret() {
+/*
   int field_size;
   field_size = EC_GROUP_get_degree(EC_KEY_get0_group(key_)); // deprecated
   if (field_size <= 0) {
@@ -227,6 +155,7 @@ std::vector<uint8_t> ECDH::GetSecret() {
   }
 
   //return secret;
+*/
 
   // new implementation
   size_t skey_len;
@@ -235,7 +164,14 @@ std::vector<uint8_t> ECDH::GetSecret() {
     fprintf(stdout, "Failed. get size of key: error %d\n", error);
     std::exit(1);
   }
-  fprintf(stdout, "size of skey: %u. secret.size() : %u\n", skey_len, secret.size());
+
+  std::vector<uint8_t> secret(skey_len);
+  if ((error = EVP_PKEY_derive(pctx2_, secret.data(), &skey_len)) <= 0){
+    fprintf(stdout, "Failed. get size of key: error %d\n", error);
+    std::exit(1);
+  }
+  fprintf(stdout, "size of skey: %lu. secret.size() : %lu\n", skey_len, secret.size());
+
 
 
 

--- a/quic/tls/ecdh.hpp
+++ b/quic/tls/ecdh.hpp
@@ -24,6 +24,10 @@ private:
   EVP_PKEY *pkey_;
   EVP_PKEY_CTX *pctx_;
 
+  EVP_PKEY_CTX *pctx2_;
+  EVP_PKEY *peer_pkey_;
+
+
 };
 
 } // namespace tls

--- a/quic/tls/ecdh.hpp
+++ b/quic/tls/ecdh.hpp
@@ -7,6 +7,7 @@
 #include <openssl/ecdh.h>
 #include <openssl/evp.h>
 
+
 namespace tls {
 
 class ECDH {
@@ -19,6 +20,10 @@ public:
 private:
   EC_KEY *key_;
   EC_POINT *peer_;
+
+  EVP_PKEY *pkey_;
+  EVP_PKEY_CTX *pctx_;
+
 };
 
 } // namespace tls

--- a/quic/tls/hkdf.cpp
+++ b/quic/tls/hkdf.cpp
@@ -42,8 +42,6 @@ std::vector<uint8_t> HKDF::ExpandLabel(std::vector<uint8_t> &secret,
                                        std::string label_string,
                                        std::vector<uint8_t> &context,
                                        size_t key_length) {
-  printf("HKDF::ExpandLabel\n");
-
   std::string label = {static_cast<char>((key_length & 0xff00) >> 8),
                        static_cast<char>((key_length & 0xff))};
   label_string = "tls13 " + label_string;


### PR DESCRIPTION
Replace following functinos whith are depreacted in OpenSSL 3.x

- EC_KEY_new_by_curve_name
-  EC_KEY_generate_key
-  i2o_ECPublicKey
-  EC_GROUP_get_degree
-  EC_KEY_get0_group
-  ECDH_compute_key
-  HMAC_CTX_new
-  HMAC_Init_ex
-  HMAC_Update
-  HMAC_Final

# note

Cause following error.

```
ERROR: EVP_CipherFinal_ex failed. test: 0, OpenSSL error: error:00000000:lib(0)::reason(0)
```